### PR TITLE
set up json5 completion demo and handle edge cases

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -54,11 +54,13 @@
         display: grid;
         grid-auto-columns: 50%;
         grid-template-areas: "a a";
+        gap: 1rem;
       }
       @media screen and (max-width: 768px) {
         .grid-row {
           grid-auto-columns: 100%;
           grid-template-areas: "a" "b";
+          gap: 0;
         }
       }
     </style>

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -22,10 +22,14 @@ import { json, jsonLanguage, jsonParseLinter } from "@codemirror/lang-json";
 import { jsonSchemaLinter, jsonSchemaHover, jsonCompletion } from "../src";
 
 // json5
-import { json5, json5ParseLinter } from "codemirror-json5";
+import { json5, json5ParseLinter, json5Language } from "codemirror-json5";
 import { json5SchemaLinter, json5SchemaHover } from "../src/json5";
 
 const schema = packageJsonSchema as JSONSchema7;
+
+const customLinterOptions = {
+  delay: 200,
+};
 
 const commonExtensions = [
   gutter({ class: "CodeMirror-lint-markers" }),
@@ -45,10 +49,10 @@ const commonExtensions = [
 const state = EditorState.create({
   doc: jsonText,
   extensions: [
-    ...commonExtensions,
+    commonExtensions,
     json(),
-    linter(jsonParseLinter()),
-    linter(jsonSchemaLinter(schema)),
+    linter(jsonParseLinter(), customLinterOptions),
+    linter(jsonSchemaLinter(schema), customLinterOptions),
     jsonLanguage.data.of({
       autocomplete: jsonCompletion(schema),
     }),
@@ -64,10 +68,14 @@ new EditorView({
 const json5State = EditorState.create({
   doc: json5Text,
   extensions: [
-    ...commonExtensions,
+    commonExtensions,
     json5(),
-    linter(json5ParseLinter()),
-    linter(json5SchemaLinter(schema)),
+
+    linter(json5ParseLinter(), customLinterOptions),
+    linter(json5SchemaLinter(schema), customLinterOptions),
+    json5Language.data.of({
+      autocomplete: jsonCompletion(schema),
+    }),
     hoverTooltip(json5SchemaHover(schema)),
   ],
 });

--- a/dev/sample-text.ts
+++ b/dev/sample-text.ts
@@ -1,21 +1,18 @@
-export const jsonText = `{
-  "name": "lexunicon",
-  "version": "0.0.0",
-  "description": "A lexicon for the unicon programming language",
-  "contributors": [{
-    "email": "email",
-    "url": "h"
-  }],
-  "type": ""
-}`;
+import json5 from "json5";
 
 export const json5Text = `{
   "name": "lexunicon",
   "version": "0.0.0",
   description: 'A lexicon for the unicon programming language',
-  contributors: [{
-    email: "email",
-    "url": 'h',
-  }],
+  contributors: [
+    {
+      email: "email",
+      "url": 'ht',
+    }
+  ],
+  // ecmascript2042
   'type': '',
+  exports: false
 }`;
+
+export const jsonText = JSON.stringify(json5.parse(json5Text), null, 2);

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -64,7 +64,7 @@ provides a JSON schema enabled autocomplete extension for codemirror
 
 #### Defined in
 
-[json-completion.ts:749](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/json-completion.ts#L749)
+[json-completion.ts:774](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/json-completion.ts#L774)
 
 ---
 
@@ -101,7 +101,7 @@ provides a JSON schema enabled tooltip extension for codemirror
 
 #### Defined in
 
-[json-hover.ts:38](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/json-hover.ts#L38)
+[json-hover.ts:38](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/json-hover.ts#L38)
 
 ---
 
@@ -136,7 +136,7 @@ Helper for simpler class instantiaton
 
 #### Defined in
 
-[json-validation.ts:35](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/json-validation.ts#L35)
+[json-validation.ts:35](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/json-validation.ts#L35)
 
 ## Utilities
 
@@ -159,7 +159,7 @@ retrieve a Map of all the json pointers in a document
 
 #### Defined in
 
-[utils/jsonPointers.ts:56](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/utils/jsonPointers.ts#L56)
+[utils/jsonPointers.ts:56](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/utils/jsonPointers.ts#L56)
 
 ---
 
@@ -183,7 +183,7 @@ retrieve a JSON pointer for a given position in the editor
 
 #### Defined in
 
-[utils/jsonPointers.ts:44](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/utils/jsonPointers.ts#L44)
+[utils/jsonPointers.ts:44](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/utils/jsonPointers.ts#L44)
 
 ---
 
@@ -210,7 +210,7 @@ Mimics the behavior of `json-source-map`'s `parseJSONDocument` function using co
 
 #### Defined in
 
-[utils/parseJSONDocument.ts:23](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/utils/parseJSONDocument.ts#L23)
+[utils/parseJSONDocument.ts:23](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/utils/parseJSONDocument.ts#L23)
 
 ---
 
@@ -237,7 +237,7 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[utils/parseJSONDocument.ts:9](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/utils/parseJSONDocument.ts#L9)
+[utils/parseJSONDocument.ts:9](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/utils/parseJSONDocument.ts#L9)
 
 ## Functions
 
@@ -258,7 +258,7 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[utils/jsonPointers.ts:12](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/utils/jsonPointers.ts#L12)
+[utils/jsonPointers.ts:12](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/utils/jsonPointers.ts#L12)
 
 ## Type Aliases
 
@@ -275,7 +275,7 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[json-hover.ts:12](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/json-hover.ts#L12)
+[json-hover.ts:12](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/json-hover.ts#L12)
 
 ---
 
@@ -285,7 +285,7 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[json-hover.ts:14](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/json-hover.ts#L14)
+[json-hover.ts:14](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/json-hover.ts#L14)
 
 ---
 
@@ -303,7 +303,7 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[json-hover.ts:18](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/json-hover.ts#L18)
+[json-hover.ts:18](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/json-hover.ts#L18)
 
 ---
 
@@ -313,7 +313,7 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[utils/jsonPointers.ts:8](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/utils/jsonPointers.ts#L8)
+[utils/jsonPointers.ts:8](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/utils/jsonPointers.ts#L8)
 
 ---
 
@@ -330,7 +330,7 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[types.ts:4](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/types.ts#L4)
+[types.ts:4](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/types.ts#L4)
 
 ---
 
@@ -349,7 +349,7 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[types.ts:9](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/types.ts#L9)
+[types.ts:9](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/types.ts#L9)
 
 ---
 
@@ -359,7 +359,7 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[types.ts:18](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/types.ts#L18)
+[types.ts:18](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/types.ts#L18)
 
 ---
 
@@ -376,4 +376,4 @@ Return parsed data and json pointers for a given codemirror EditorState
 
 #### Defined in
 
-[json-validation.ts:24](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/json-validation.ts#L24)
+[json-validation.ts:24](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/json-validation.ts#L24)

--- a/docs/modules/json5.md
+++ b/docs/modules/json5.md
@@ -49,7 +49,7 @@ Instantiates a JSONHover instance with the JSON5 mode
 
 #### Defined in
 
-[json5-hover.ts:13](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/json5-hover.ts#L13)
+[json5-hover.ts:13](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/json5-hover.ts#L13)
 
 ---
 
@@ -84,7 +84,7 @@ Instantiates a JSONValidation instance with the JSON5 mode
 
 #### Defined in
 
-[json5-validation.ts:10](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/json5-validation.ts#L10)
+[json5-validation.ts:10](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/json5-validation.ts#L10)
 
 ## Utilities
 
@@ -111,7 +111,7 @@ Mimics the behavior of `json-source-map`'s `parseJSONDocument` function, for jso
 
 #### Defined in
 
-[utils/parseJSON5Document.ts:28](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/utils/parseJSON5Document.ts#L28)
+[utils/parseJSON5Document.ts:28](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/utils/parseJSON5Document.ts#L28)
 
 ---
 
@@ -138,4 +138,4 @@ Return parsed data and json5 pointers for a given codemirror EditorState
 
 #### Defined in
 
-[utils/parseJSON5Document.ts:14](https://github.com/acao/codemirror-json-schema/blob/dcf7e5c/src/utils/parseJSON5Document.ts#L14)
+[utils/parseJSON5Document.ts:14](https://github.com/acao/codemirror-json-schema/blob/fcb9042/src/utils/parseJSON5Document.ts#L14)

--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
     "@lezer/common": "^1.0.3"
   },
   "devDependencies": {
-    "@evilmartians/lefthook": "^1.4.6",
     "@changesets/cli": "^2.26.2",
     "@codemirror/autocomplete": "^6.8.1",
     "@codemirror/commands": "^6.2.4",
     "@codemirror/theme-one-dark": "^6.1.2",
+    "@evilmartians/lefthook": "^1.4.6",
     "@vitest/coverage-v8": "^0.33.0",
     "codemirror": "^6.0.1",
     "codemirror-json5": "^1.0.3",

--- a/src/__tests__/json-hover.spec.ts
+++ b/src/__tests__/json-hover.spec.ts
@@ -96,6 +96,7 @@ describe("JSONHover#doHover", () => {
       arrow: true,
       end: 14,
       pos: 14,
+      above: true,
       create: expect.any(Function),
     });
     const hoverEl = hoverResult?.create(new EditorView({})).dom;
@@ -113,6 +114,7 @@ describe("JSONHover#doHover", () => {
       arrow: true,
       end: 4,
       pos: 4,
+      above: true,
       create: expect.any(Function),
     });
     const hoverEl = hoverResult?.create(new EditorView({})).dom.toString();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 export { jsonCompletion } from "./json-completion";
+
 export {
   jsonSchemaLinter,
   type JSONValidationOptions,
 } from "./json-validation";
+
 export {
   jsonSchemaHover,
   type HoverOptions,

--- a/src/json-hover.ts
+++ b/src/json-hover.ts
@@ -147,6 +147,7 @@ export class JSONHover {
       end = pos;
     try {
       const cursorData = this.getDataForCursor(view, pos, side);
+      if (!cursorData?.schema) return null;
 
       const getHoverTexts = this.opts?.getHoverTexts ?? this.getHoverTexts;
       const hoverTexts = getHoverTexts(
@@ -160,9 +161,11 @@ export class JSONHover {
         pos: start,
         end,
         arrow: true,
+        above: true,
         create: (view) => {
           return {
             dom: formattedDom,
+            hoverTime: 100,
           };
         },
       };


### PR DESCRIPTION
this adds working completion in a _lot_ of cases, but there are some broken edge cases

here are some examples of the working completions across json4 and json5, both improvements and existing
[completion-examples.webm](https://github.com/acao/codemirror-json-schema/assets/1368727/691a40a6-410f-4677-8846-2b656f016b8f)


Todo:
- tests! (I learned I need to call state.focus() before state.setCursor() to mock autocomplete!)