### PR TITLE
json5 insert text, prefer defaults

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "files.insertFinalNewline": true
+  "files.insertFinalNewline": true,
+  "coverage-gutters.coverageBaseDir": "**",
+  "coverage-gutters.coverageFileNames": ["clover.xml"]
 }

--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ This approach allows you to configure the json5 mode and parse linter, as well a
 import { EditorState } from "@codemirror/state";
 import { linter } from "@codemirror/lint";
 import { json5, json5ParseLinter, json5Language } from "codemirror-json5";
-import { jsonCompletion } from "codemirror-json-schema";
 import {
   json5SchemaLinter,
   json5SchemaHover,
+  json5Completion,
 } from "codemirror-json-schema/json5";
 
 const schema = {
@@ -182,7 +182,7 @@ const json5State = EditorState.create({
     linter(json5SchemaLinter(schema)),
     hoverTooltip(json5SchemaHover(schema)),
     json5Language.data.of({
-      autocomplete: jsonCompletion(schema),
+      autocomplete: json5Completion(schema),
     }),
   ],
 });

--- a/src/__tests__/__helpers__/completion.ts
+++ b/src/__tests__/__helpers__/completion.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vitest, Mock } from "vitest";
 
 import { json, jsonLanguage } from "@codemirror/lang-json";
+import { json5, json5Language } from "codemirror-json5";
+
 import { EditorState } from "@codemirror/state";
 import {
   Completion,
@@ -38,19 +40,26 @@ type MockedCompletionResult = CompletionResult["options"][0] & {
 export async function expectCompletion(
   doc: string,
   results: MockedCompletionResult[],
-  schema?: JSONSchema7,
-  conf: { explicit?: boolean } = {}
+
+  conf: {
+    explicit?: boolean;
+    schema?: JSONSchema7;
+    mode?: "json" | "json5";
+  } = {}
 ) {
   let cur = doc.indexOf("|"),
-    currentSchema = schema || testSchema2;
+    currentSchema = conf?.schema || testSchema2;
   doc = doc.slice(0, cur) + doc.slice(cur + 1);
+  const jsonMode = conf?.mode === "json5" ? json5 : json;
+  const jsonLang = conf?.mode === "json5" ? json5Language : jsonLanguage;
+
   let state = EditorState.create({
     doc,
     selection: { anchor: cur },
     extensions: [
-      json(),
-      jsonLanguage.data.of({
-        autocomplete: jsonCompletion(currentSchema),
+      jsonMode(),
+      jsonLang.data.of({
+        autocomplete: jsonCompletion(currentSchema, { mode: conf.mode }),
       }),
     ],
   });

--- a/src/__tests__/json-completion.spec.ts
+++ b/src/__tests__/json-completion.spec.ts
@@ -46,9 +46,7 @@ describe("jsonCompletion", () => {
         type: "property",
         detail: "",
         info: "an example enum with default bar",
-        // TODO: should this not autocomplete to default "bar"?
-        // template: '"enum1": "${bar}"',
-        template: '"enum1": #{}',
+        template: '"enum1": "${bar}"',
       },
       {
         label: "enum2",
@@ -162,5 +160,104 @@ describe("jsonCompletion", () => {
         type: "property",
       },
     ]);
+  });
+});
+
+describe("json5Completion", () => {
+  it("should return bare property key when no quotes are used", async () => {
+    await expectCompletion(
+      "{ f| }",
+      [
+        {
+          label: "foo",
+          type: "property",
+          detail: "string",
+          info: "",
+          template: "foo: '#{}'",
+        },
+      ],
+      { mode: "json5" }
+    );
+  });
+  it("should return template for '", async () => {
+    await expectCompletion(
+      "{ 'one|' }",
+      [
+        {
+          label: "oneOfEg",
+          type: "property",
+          detail: "",
+          info: "an example oneOf",
+          template: "'oneOfEg': ",
+        },
+        {
+          label: "oneOfEg2",
+          type: "property",
+          detail: "",
+          info: "",
+          template: "'oneOfEg2': ",
+        },
+        {
+          detail: "",
+          info: "",
+          label: "oneOfObject",
+          template: "'oneOfObject': ",
+          type: "property",
+        },
+      ],
+      { mode: "json5" }
+    );
+  });
+  it("should include defaults for enum when available", async () => {
+    await expectCompletion(
+      '{ "en|" }',
+      [
+        {
+          label: "enum1",
+          type: "property",
+          detail: "",
+          info: "an example enum with default bar",
+          template: '"enum1": "${bar}"',
+        },
+        {
+          label: "enum2",
+          type: "property",
+          detail: "",
+          info: "an example enum without default",
+          template: '"enum2": #{}',
+        },
+      ],
+      { mode: "json5" }
+    );
+  });
+  it("should include defaults for boolean when available", async () => {
+    await expectCompletion(
+      "{ booleanW| }",
+      [
+        {
+          type: "property",
+          detail: "boolean",
+          info: "an example boolean with default",
+          label: "booleanWithDefault",
+          template: "booleanWithDefault: ${true}",
+        },
+      ],
+      { mode: "json5" }
+    );
+  });
+  it("should include insert text for nested object properties", async () => {
+    await expectCompletion(
+      "{ object: { f|  }",
+      [
+        {
+          type: "property",
+          detail: "string",
+          info: "an elegant string",
+          label: "foo",
+          template: "foo: '#{}'",
+        },
+      ],
+      { mode: "json5" }
+    );
   });
 });

--- a/src/__tests__/json-completion.spec.ts
+++ b/src/__tests__/json-completion.spec.ts
@@ -107,6 +107,18 @@ describe("jsonCompletion", () => {
       },
     ]);
   });
+  // TODO: accidentally steps up to the parent pointer
+  it.skip("should include insert text for nested object properties", async () => {
+    await expectCompletion(`{ "object": { '| } }`, [
+      {
+        detail: "string",
+        info: "an elegant string",
+        label: "foo",
+        template: '"foo": "#{}"',
+        type: "property",
+      },
+    ]);
+  });
   it("should include insert text for nested object properties with filter", async () => {
     await expectCompletion('{ "object": { "f|" } }', [
       {
@@ -160,6 +172,38 @@ describe("jsonCompletion", () => {
         type: "property",
       },
     ]);
+    it("should autocomplete for oneOf without quotes", async () => {
+      await expectCompletion('{ "oneOfObject": { | } }', [
+        {
+          detail: "string",
+          info: "",
+          label: "foo",
+          template: '"foo": "#{}"',
+          type: "property",
+        },
+        {
+          detail: "number",
+          info: "",
+          label: "bar",
+          template: '"bar": #{0}',
+          type: "property",
+        },
+        {
+          detail: "string",
+          info: "",
+          label: "apple",
+          template: '"apple": "#{}"',
+          type: "property",
+        },
+        {
+          detail: "number",
+          info: "",
+          label: "banana",
+          template: '"banana": #{0}',
+          type: "property",
+        },
+      ]);
+    });
   });
 });
 
@@ -255,6 +299,42 @@ describe("json5Completion", () => {
           info: "an elegant string",
           label: "foo",
           template: "foo: '#{}'",
+        },
+      ],
+      { mode: "json5" }
+    );
+  });
+  it("should include insert text for nested oneOf object properties with a single quote", async () => {
+    await expectCompletion(
+      "{ oneOfObject: { '|'  }",
+      [
+        {
+          type: "property",
+          detail: "string",
+          info: "",
+          label: "foo",
+          template: "'foo': '#{}'",
+        },
+        {
+          type: "property",
+          detail: "number",
+          info: "",
+          label: "bar",
+          template: "'bar': #{0}",
+        },
+        {
+          type: "property",
+          detail: "string",
+          info: "",
+          label: "apple",
+          template: "'apple': '#{}'",
+        },
+        {
+          type: "property",
+          detail: "number",
+          info: "",
+          label: "banana",
+          template: "'banana': #{0}",
         },
       ],
       { mode: "json5" }

--- a/src/json-completion.ts
+++ b/src/json-completion.ts
@@ -14,7 +14,7 @@ import {
   getWord,
   isPropertyNameNode,
   isPrimitiveValueNode,
-  stripSurrondingQuotes,
+  stripSurroundingQuotes,
   getNodeAtPosition,
 } from "./utils/node";
 import { Draft07, JsonError } from "json-schema-library";
@@ -169,10 +169,8 @@ export class JSONCompletion {
     }
 
     // handle filtering
-    result.options = Array.from(collector.completions.values()).filter(
-      (v) =>
-        stripSurrondingQuotes(v.label).startsWith(prefix) ||
-        stripSurrondingQuotes(v.label) === prefix
+    result.options = Array.from(collector.completions.values()).filter((v) =>
+      stripSurroundingQuotes(v.label).startsWith(prefix)
     );
     debug.log(
       "xxx",
@@ -209,7 +207,7 @@ export class JSONCompletion {
     debug.log("xxx", "getPropertyCompletions", node, ctx, properties);
     properties.forEach((p) => {
       const key = getWord(ctx.state.doc, p.getChild(TOKENS.PROPERTY_NAME));
-      collector.reserve(stripSurrondingQuotes(key));
+      collector.reserve(stripSurroundingQuotes(key));
     });
 
     // TODO: Handle separatorAfter

--- a/src/json-completion.ts
+++ b/src/json-completion.ts
@@ -308,7 +308,6 @@ export class JSONCompletion {
     let nValueProposals = 0;
     if (typeof propertySchema === "object") {
       if (typeof propertySchema.default !== "undefined") {
-        console.log("default", propertySchema.default, value);
         if (!value) {
           value = this.getInsertTextForGuessedValue(propertySchema.default, "");
         }

--- a/src/json-completion.ts
+++ b/src/json-completion.ts
@@ -806,3 +806,17 @@ export function jsonCompletion(
     return completion.doComplete(ctx);
   };
 }
+
+/**
+ * provides a JSON schema enabled autocomplete extension for codemirror and json5
+ * @group Codemirror Extensions
+ */
+export function json5Completion(
+  schema: JSONSchema7,
+  opts: Omit<JSONCompletionOptions, "mode"> = {}
+) {
+  const completion = new JSONCompletion(schema, { ...opts, mode: "json5" });
+  return function jsonDoCompletion(ctx: CompletionContext) {
+    return completion.doComplete(ctx);
+  };
+}

--- a/src/json-completion.ts
+++ b/src/json-completion.ts
@@ -405,7 +405,7 @@ export class JSONCompletion {
         let snippetValue = JSON.stringify(value);
         snippetValue = snippetValue.substr(1, snippetValue.length - 2); // remove quotes
         snippetValue = this.getInsertTextForPlainText(snippetValue); // escape \ and }
-        return '"${' + snippetValue + '}"';
+        return '"${' + snippetValue + '}"' + separatorAfter;
       }
       case "number":
       case "boolean":

--- a/src/json-completion.ts
+++ b/src/json-completion.ts
@@ -315,64 +315,68 @@ export class JSONCompletion {
           value = this.getInsertTextForGuessedValue(propertySchema.default, "");
         }
         nValueProposals++;
-      }
-      if (propertySchema.enum) {
-        if (!value && propertySchema.enum.length === 1) {
-          value = this.getInsertTextForGuessedValue(propertySchema.enum[0], "");
-        }
-        nValueProposals += propertySchema.enum.length;
-      }
-      if (typeof propertySchema.const !== "undefined") {
-        if (!value) {
-          value = this.getInsertTextForGuessedValue(propertySchema.const, "");
-        }
-        nValueProposals++;
-      }
-      if (
-        Array.isArray(propertySchema.examples) &&
-        propertySchema.examples.length
-      ) {
-        if (!value) {
-          value = this.getInsertTextForGuessedValue(
-            propertySchema.examples[0],
-            ""
-          );
-        }
-        nValueProposals += propertySchema.examples.length;
-      }
-      if (value === undefined && nValueProposals === 0) {
-        let type = Array.isArray(propertySchema.type)
-          ? propertySchema.type[0]
-          : propertySchema.type;
-        if (!type) {
-          if (propertySchema.properties) {
-            type = "object";
-          } else if (propertySchema.items) {
-            type = "array";
+      } else {
+        if (propertySchema.enum) {
+          if (!value && propertySchema.enum.length === 1) {
+            value = this.getInsertTextForGuessedValue(
+              propertySchema.enum[0],
+              ""
+            );
           }
+          nValueProposals += propertySchema.enum.length;
         }
-        switch (type) {
-          case "boolean":
-            value = "#{}";
-            break;
-          case "string":
-            value = isJSON5 ? "'#{}'" : '"#{}"';
-            break;
-          case "object":
-            value = "{#{}}";
-            break;
-          case "array":
-            value = "[#{}]";
-            break;
-          case "number":
-          case "integer":
-            value = "#{0}";
-            break;
-          case "null":
-            value = "#{null}";
-            break;
-          default:
-            return resultText;
+        if (typeof propertySchema.const !== "undefined") {
+          if (!value) {
+            value = this.getInsertTextForGuessedValue(propertySchema.const, "");
+          }
+          nValueProposals++;
+        }
+        if (
+          Array.isArray(propertySchema.examples) &&
+          propertySchema.examples.length
+        ) {
+          if (!value) {
+            value = this.getInsertTextForGuessedValue(
+              propertySchema.examples[0],
+              ""
+            );
+          }
+          nValueProposals += propertySchema.examples.length;
+        }
+        if (value === undefined && nValueProposals === 0) {
+          let type = Array.isArray(propertySchema.type)
+            ? propertySchema.type[0]
+            : propertySchema.type;
+          if (!type) {
+            if (propertySchema.properties) {
+              type = "object";
+            } else if (propertySchema.items) {
+              type = "array";
+            }
+          }
+          switch (type) {
+            case "boolean":
+              value = "#{}";
+              break;
+            case "string":
+              value = isJSON5 ? "'#{}'" : '"#{}"';
+              break;
+            case "object":
+              value = "{#{}}";
+              break;
+            case "array":
+              value = "[#{}]";
+              break;
+            case "number":
+            case "integer":
+              value = "#{0}";
+              break;
+            case "null":
+              value = "#{null}";
+              break;
+            default:
+              return resultText;
+          }
         }
       }
     }

--- a/src/json5-bundled.ts
+++ b/src/json5-bundled.ts
@@ -17,7 +17,7 @@ export function json5Schema(schema: JSONSchema7) {
     linter(json5ParseLinter()),
     linter(json5SchemaLinter(schema)),
     json5Language.data.of({
-      autocomplete: jsonCompletion(schema),
+      autocomplete: jsonCompletion(schema, { mode: "json5" }),
     }),
     hoverTooltip(json5SchemaHover(schema)),
   ];

--- a/src/json5-bundled.ts
+++ b/src/json5-bundled.ts
@@ -1,7 +1,7 @@
 import { JSONSchema7 } from "json-schema";
 import { json5, json5Language, json5ParseLinter } from "codemirror-json5";
 import { hoverTooltip } from "@codemirror/view";
-import { jsonCompletion } from "./json-completion";
+import { json5Completion } from "./json-completion";
 import { json5SchemaLinter } from "./json5-validation";
 import { json5SchemaHover } from "./json5-hover";
 
@@ -17,7 +17,7 @@ export function json5Schema(schema: JSONSchema7) {
     linter(json5ParseLinter()),
     linter(json5SchemaLinter(schema)),
     json5Language.data.of({
-      autocomplete: jsonCompletion(schema, { mode: "json5" }),
+      autocomplete: json5Completion(schema),
     }),
     hoverTooltip(json5SchemaHover(schema)),
   ];

--- a/src/json5.ts
+++ b/src/json5.ts
@@ -1,6 +1,7 @@
 // json5
 export { json5SchemaLinter } from "./json5-validation";
 export { json5SchemaHover } from "./json5-hover";
+export { json5Completion } from "./json-completion";
 
 /**
  * @group Bundled Codemirror Extensions

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -12,7 +12,7 @@ export const getNodeAtPosition = (
   return syntaxTree(state).resolveInner(pos, side);
 };
 
-export const stripSurrondingQuotes = (str: string) => {
+export const stripSurroundingQuotes = (str: string) => {
   return str.replace(/^"(.*)"$/, "$1").replace(/^'(.*)'$/, "$1");
 };
 
@@ -22,7 +22,7 @@ export const getWord = (
   stripQuotes = true
 ) => {
   const word = node ? doc.sliceString(node.from, node.to) : "";
-  return stripQuotes ? stripSurrondingQuotes(word) : word;
+  return stripQuotes ? stripSurroundingQuotes(word) : word;
 };
 
 export const isInvalidValueNode = (node: SyntaxNode) => {


### PR DESCRIPTION
this allows us to:

- automatically complete the json5 string based on the type of quotes or lack thereof that the user is using
- prefers the schema.default over other guesses
- fixes an apparent bug where guessed solutions are overwritten

I tested this with `packageJson.types`, which is the only value in the schema that has a default