### PR TITLE
add more completion tests

### DIFF
--- a/src/__tests__/__fixtures__/schemas.ts
+++ b/src/__tests__/__fixtures__/schemas.ts
@@ -35,7 +35,43 @@ export const testSchema2 = {
     oneOfEg2: {
       oneOf: [{ type: "string" }, { type: "array" }],
     },
+    oneOfObject: {
+      oneOf: [
+        { $ref: "#/definitions/fancyObject" },
+        { $ref: "#/definitions/fancyObject2" },
+      ],
+    },
+    enum1: {
+      description: "an example enum with default bar",
+      enum: ["foo", "bar"],
+      default: "bar",
+    },
+    enum2: {
+      description: "an example enum without default",
+      enum: ["foo", "bar"],
+    },
+    booleanWithDefault: {
+      description: "an example boolean with default",
+      default: true,
+      type: "boolean",
+    },
   },
   required: ["foo", "object.foo"],
   additionalProperties: false,
+  definitions: {
+    fancyObject: {
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+        bar: { type: "number" },
+      },
+    },
+    fancyObject2: {
+      type: "object",
+      properties: {
+        apple: { type: "string" },
+        banana: { type: "number" },
+      },
+    },
+  },
 } as JSONSchema7;

--- a/src/__tests__/json-completion.spec.ts
+++ b/src/__tests__/json-completion.spec.ts
@@ -30,6 +30,137 @@ describe("jsonCompletion", () => {
         info: "",
         template: '"oneOfEg2": ',
       },
+      {
+        detail: "",
+        info: "",
+        label: "oneOfObject",
+        template: '"oneOfObject": ',
+        type: "property",
+      },
+    ]);
+  });
+  it("should include defaults for enum when available", async () => {
+    await expectCompletion('{ "en| }', [
+      {
+        label: "enum1",
+        type: "property",
+        detail: "",
+        info: "an example enum with default bar",
+        // TODO: should this not autocomplete to default "bar"?
+        // template: '"enum1": "${bar}"',
+        template: '"enum1": #{}',
+      },
+      {
+        label: "enum2",
+        type: "property",
+        detail: "",
+        info: "an example enum without default",
+        template: '"enum2": #{}',
+      },
+    ]);
+  });
+  it("should include value completions for enum", async () => {
+    await expectCompletion('{ "enum1": "|" }', [
+      {
+        label: '"foo"',
+        info: "an example enum with default bar",
+      },
+      {
+        label: '"bar"',
+        detail: "Default value",
+      },
+    ]);
+  });
+  it("should include defaults for boolean when available", async () => {
+    await expectCompletion('{ "booleanW| }', [
+      {
+        type: "property",
+        detail: "boolean",
+        info: "an example boolean with default",
+        label: "booleanWithDefault",
+        template: '"booleanWithDefault": ${true}',
+      },
+    ]);
+  });
+  // TODO: should provide true/false completions
+  it("should include value completions for boolean", async () => {
+    await expectCompletion('{ "booleanWithDefault": | }', []);
+  });
+  it("should include insert text for objects", async () => {
+    await expectCompletion('{ "ob| }', [
+      {
+        type: "property",
+        detail: "object",
+        info: "",
+        label: "object",
+        template: '"object": {#{}}',
+      },
+    ]);
+  });
+  // this has regressed for json4 only for some reason
+  it("should include insert text for nested object properties", async () => {
+    await expectCompletion('{ "object": { "|" } }', [
+      {
+        detail: "string",
+        info: "an elegant string",
+        label: "foo",
+        template: '"foo": "#{}"',
+        type: "property",
+      },
+    ]);
+  });
+  it("should include insert text for nested object properties with filter", async () => {
+    await expectCompletion('{ "object": { "f|" } }', [
+      {
+        detail: "string",
+        info: "an elegant string",
+        label: "foo",
+        template: '"foo": "#{}"',
+        type: "property",
+      },
+    ]);
+  });
+  it("should autocomplete for oneOf with nested definitions and filter", async () => {
+    await expectCompletion('{ "oneOfObject": { "f|" } }', [
+      {
+        detail: "string",
+        info: "",
+        label: "foo",
+        template: '"foo": "#{}"',
+        type: "property",
+      },
+    ]);
+  });
+  it("should autocomplete for oneOf with nested definitions", async () => {
+    await expectCompletion('{ "oneOfObject": { "|" } }', [
+      {
+        detail: "string",
+        info: "",
+        label: "foo",
+        template: '"foo": "#{}"',
+        type: "property",
+      },
+      {
+        detail: "number",
+        info: "",
+        label: "bar",
+        template: '"bar": #{0}',
+        type: "property",
+      },
+      {
+        detail: "string",
+        info: "",
+        label: "apple",
+        template: '"apple": "#{}"',
+        type: "property",
+      },
+      {
+        detail: "number",
+        info: "",
+        label: "banana",
+        template: '"banana": #{0}',
+        type: "property",
+      },
     ]);
   });
 });


### PR DESCRIPTION
@imolorhe here i've extracted much of the test coverage so we can catch regressions after the json5 completion tweaks