### PR TITLE
failing case for json4 completion

### DIFF
--- a/src/__tests__/json-completion.spec.ts
+++ b/src/__tests__/json-completion.spec.ts
@@ -32,4 +32,16 @@ describe("jsonCompletion", () => {
       },
     ]);
   });
+  // TODO: fix this failing case
+  it("should include insert text for nested object properties", async () => {
+    await expectCompletion(`{ "object": { '| } }`, [
+      {
+        detail: "string",
+        info: "an elegant string",
+        label: "foo",
+        template: '"foo": "#{}"',
+        type: "property",
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
this test will fail on purpose, we need to make it green!

and also ensure the fix works in deeply nested objects - for example, this case should not cause it to offer completions for any parent object

this seems to be something to work from:
![image](https://github.com/acao/codemirror-json-schema/assets/1368727/7a645390-a4e4-4009-ad13-1f9a15b768d6)

from what I can tell, this fixes it?

![image](https://github.com/acao/codemirror-json-schema/assets/1368727/17397161-a386-4214-9482-999d59ffc98d)

