### PR TITLE
remove json-schema

### DIFF
--- a/.changeset/chatty-cooks-cover.md
+++ b/.changeset/chatty-cooks-cover.md
@@ -1,0 +1,5 @@
+---
+"codemirror-json-schema": patch
+---
+
+remove json-schema dep

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@sagold/json-pointer": "^5.1.1",
     "@types/json-schema": "^7.0.12",
     "@types/node": "^20.4.2",
-    "json-schema": "^0.2.3",
     "json-schema-library": "^8.0.0"
   },
   "optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ dependencies:
   '@types/node':
     specifier: ^20.4.2
     version: 20.4.2
-  json-schema:
-    specifier: ^0.2.3
-    version: 0.2.3
   json-schema-library:
     specifier: ^8.0.0
     version: 8.0.0
@@ -1947,10 +1944,6 @@ packages:
       fast-copy: 3.0.1
       fast-deep-equal: 3.1.3
       valid-url: 1.0.9
-    dev: false
-
-  /json-schema@0.2.3:
-    resolution: {integrity: sha512-a3xHnILGMtk+hDOqNwHzF6e2fNbiMrXZvxKQiEv2MlgQP+pjIOzqAmKYD2mDpXYE/44M7g+n9p2bKkYWDUcXCQ==}
     dev: false
 
   /json5@2.2.3:


### PR DESCRIPTION
It is unused (I think, since `pnpm build` and  `pnpm test` pass for me locally) and more importantly Dependabot is yowling at me that `0.2.3` has a "Critical" CVE, (which I don't mind talking about publically because you don't use this dep).

![image](https://github.com/acao/codemirror-json-schema/assets/109672176/b2b9d6dd-6b72-4e66-afb4-23d46025ed8e)
