### PR TITLE
Add support for yaml flow mapping and sequence

### DIFF
--- a/.changeset/twelve-starfishes-thank.md
+++ b/.changeset/twelve-starfishes-thank.md
@@ -1,0 +1,5 @@
+---
+"codemirror-json-schema": patch
+---
+
+Add support for YAML flow sequences and flow mappings

--- a/src/__tests__/json-validation.spec.ts
+++ b/src/__tests__/json-validation.spec.ts
@@ -286,8 +286,8 @@ object: {}
   `,
       errors: [
         {
-          from: 13,
-          to: 19,
+          from: 21,
+          to: 23,
           message: "The required property `foo` is missing at `object`",
         },
       ],

--- a/src/__tests__/json-validation.spec.ts
+++ b/src/__tests__/json-validation.spec.ts
@@ -41,7 +41,7 @@ const expectErrors = (
 };
 
 describe("json-validation", () => {
-  it.each([
+  const jsonSuite = [
     {
       name: "provide range for a value error",
       mode: MODES.JSON,
@@ -137,6 +137,9 @@ describe("json-validation", () => {
       ],
       schema: testSchema2,
     },
+  ];
+  it.each([
+    ...jsonSuite,
     // JSON5
     {
       name: "provide range for a value error",
@@ -234,6 +237,7 @@ describe("json-validation", () => {
       schema: testSchema2,
     },
     // YAML
+    ...jsonSuite.map((t) => ({ ...t, mode: MODES.YAML })),
     {
       name: "provide range for a value error",
       mode: MODES.YAML,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,8 @@ export const YAML_TOKENS_MAPPING: Record<
   Key: TOKENS.PROPERTY_NAME,
   BlockSequence: TOKENS.ARRAY,
   BlockMapping: TOKENS.OBJECT,
+  FlowSequence: TOKENS.ARRAY,
+  FlowMapping: TOKENS.OBJECT,
   QuotedLiteral: TOKENS.STRING,
   Literal: TOKENS.STRING, // best guess
   Stream: TOKENS.JSON_TEXT,


### PR DESCRIPTION
To test, copy package.json demo content to package.yaml editor

Before:

![20240511-043150](https://github.com/acao/codemirror-json-schema/assets/11596445/95bac852-61cd-4323-900f-ae866e0fdb6e)

It does not mark missing name and format errors in .contributors[0]

After:

![20240511-043212](https://github.com/acao/codemirror-json-schema/assets/11596445/b452aac1-8a84-49a9-952d-809c17b62a12)

Since yaml is a superset of json, I've also make all json validation test cases to be run under yaml mode.