### PR TITLE
Improvements to completion logic (mainly for top level)

### DIFF
--- a/.changeset/perfect-balloons-teach.md
+++ b/.changeset/perfect-balloons-teach.md
@@ -1,0 +1,5 @@
+---
+"codemirror-json-schema": patch
+---
+
+Improvements to completion logic (mainly for top level)

--- a/src/__tests__/__fixtures__/schemas.ts
+++ b/src/__tests__/__fixtures__/schemas.ts
@@ -17,6 +17,16 @@ export const testSchema2 = {
     foo: {
       type: "string",
     },
+    stringWithDefault: {
+      type: "string",
+      description: "a string with a default value",
+      default: "defaultString",
+    },
+    bracedStringDefault: {
+      type: "string",
+      description: "a string with a default value containing braces",
+      default: "✨ A message from %{whom}: ✨",
+    },
     object: {
       type: "object",
       properties: {

--- a/src/__tests__/__helpers__/completion.ts
+++ b/src/__tests__/__helpers__/completion.ts
@@ -47,7 +47,7 @@ export async function expectCompletion(
   } = {}
 ) {
   let cur = doc.indexOf("|"),
-    currentSchema = conf?.schema || testSchema2;
+    currentSchema = conf?.schema ?? testSchema2;
   doc = doc.slice(0, cur) + doc.slice(cur + 1);
 
   let state = EditorState.create({

--- a/src/__tests__/json-completion.spec.ts
+++ b/src/__tests__/json-completion.spec.ts
@@ -140,7 +140,7 @@ describe.each([
       },
     ],
   },
-  // TODO: should provide true/false completions
+  // TODO: should provide true/false completions. Issue is the detected node is the Property node, which contains the property name and value. The prefix for the autocompletion therefore contains the property name, so it never matches the results
   // {
   //   name: "include value completions for boolean",
   //   mode: MODES.JSON,

--- a/src/__tests__/json-completion.spec.ts
+++ b/src/__tests__/json-completion.spec.ts
@@ -2,6 +2,7 @@ import { describe, it } from "vitest";
 
 import { expectCompletion } from "./__helpers__/completion.js";
 import { MODES } from "../constants.js";
+import { testSchema3 } from "./__fixtures__/schemas.js";
 
 describe.each([
   {
@@ -46,6 +47,35 @@ describe.each([
       },
     ],
   },
+  {
+    name: "include defaults for string when available",
+    mode: MODES.JSON,
+    docs: ['{ "stringWithDefault| }'],
+    expectedResults: [
+      {
+        label: "stringWithDefault",
+        type: "property",
+        detail: "string",
+        info: "a string with a default value",
+        template: '"stringWithDefault": "${defaultString}"',
+      },
+    ],
+  },
+  // TODO: fix the default template with braces: https://discuss.codemirror.net/t/inserting-literal-via-snippets/8136/4
+  // {
+  //   name: "include defaults for string with braces",
+  //   mode: MODES.JSON,
+  //   docs: ['{ "bracedStringDefault| }'],
+  //   expectedResults: [
+  //     {
+  //       label: "bracedStringDefault",
+  //       type: "property",
+  //       detail: "string",
+  //       info: "a string with a default value containing braces",
+  //       template: '"bracedStringDefault": "${✨ A message from %{whom}: ✨}"',
+  //     },
+  //   ],
+  // },
   {
     name: "include defaults for enum when available",
     mode: MODES.JSON,
@@ -222,6 +252,20 @@ describe.each([
   },
   // TODO: completion for array of objects should enhance the template
   {
+    name: "autocomplete for array of objects with filter",
+    mode: MODES.JSON,
+    docs: ['{ "arrayOfObjects": [ { "f|" } ] }'],
+    expectedResults: [
+      {
+        detail: "string",
+        info: "",
+        label: "foo",
+        template: '"foo": "#{}"',
+        type: "property",
+      },
+    ],
+  },
+  {
     name: "autocomplete for array of objects with items",
     mode: MODES.JSON,
     docs: ['{ "array| }'],
@@ -297,6 +341,28 @@ describe.each([
         type: "property",
       },
     ],
+  },
+  {
+    name: "autocomplete for a schema with top level $ref",
+    mode: MODES.JSON,
+    docs: ['{ "| }'],
+    expectedResults: [
+      {
+        type: "property",
+        detail: "string",
+        info: "",
+        label: "foo",
+        template: '"foo": "#{}"',
+      },
+      {
+        type: "property",
+        detail: "number",
+        info: "",
+        label: "bar",
+        template: '"bar": #{0}',
+      },
+    ],
+    schema: testSchema3,
   },
   // JSON5
   {
@@ -653,8 +719,8 @@ describe.each([
       },
     ],
   },
-])("jsonCompletion", ({ name, docs, mode, expectedResults }) => {
+])("jsonCompletion", ({ name, docs, mode, expectedResults, schema }) => {
   it.each(docs)(`${name} (mode: ${mode})`, async (doc) => {
-    await expectCompletion(doc, expectedResults, { mode });
+    await expectCompletion(doc, expectedResults, { mode, schema });
   });
 });

--- a/src/__tests__/json-completion.spec.ts
+++ b/src/__tests__/json-completion.spec.ts
@@ -2,7 +2,7 @@ import { describe, it } from "vitest";
 
 import { expectCompletion } from "./__helpers__/completion.js";
 import { MODES } from "../constants.js";
-import { testSchema3 } from "./__fixtures__/schemas.js";
+import { testSchema3, testSchema4 } from "./__fixtures__/schemas.js";
 
 describe.each([
   {
@@ -143,10 +143,8 @@ describe.each([
   // TODO: should provide true/false completions
   // {
   //   name: "include value completions for boolean",
-  // mode: MODES.JSON,
-  // docs: ['{ "booleanWithDefault": | }',
-  //  },
-  //   ],
+  //   mode: MODES.JSON,
+  //   docs: ['{ "booleanWithDefault": | }'],
   //   expectedResults: [
   //     {
   //       detail: "boolean",
@@ -363,6 +361,28 @@ describe.each([
       },
     ],
     schema: testSchema3,
+  },
+  {
+    name: "autocomplete for a schema with top level complex type",
+    mode: MODES.JSON,
+    docs: ['{ "| }'],
+    expectedResults: [
+      {
+        type: "property",
+        detail: "string",
+        info: "",
+        label: "foo",
+        template: '"foo": "#{}"',
+      },
+      {
+        type: "property",
+        detail: "number",
+        info: "",
+        label: "bar",
+        template: '"bar": #{0}',
+      },
+    ],
+    schema: testSchema4,
   },
   // JSON5
   {

--- a/src/json-completion.ts
+++ b/src/json-completion.ts
@@ -58,7 +58,8 @@ export class JSONCompletion {
     this.mode = opts.mode ?? MODES.JSON;
   }
   public doComplete(ctx: CompletionContext) {
-    this.schema = getJSONSchema(ctx.state)!;
+    const s = getJSONSchema(ctx.state)!;
+    this.schema = this.expandSchemaProperty(s, s) ?? s;
     if (!this.schema) {
       // todo: should we even do anything without schema
       // without taking over the existing mode responsibilties?
@@ -484,13 +485,10 @@ export class JSONCompletion {
     switch (this.mode) {
       case MODES.JSON5:
         return `'${prf}{${value}}'`;
-        break;
       case MODES.YAML:
         return `${prf}{${value}}`;
-        break;
       default:
         return `"${prf}{${value}}"`;
-        break;
     }
   }
 
@@ -847,8 +845,8 @@ export class JSONCompletion {
     return [subSchema as JSONSchema7];
   }
 
-  private expandSchemaProperty(
-    property: JSONSchema7Definition,
+  private expandSchemaProperty<T extends JSONSchema7Definition>(
+    property: T,
     schema: JSONSchema7
   ) {
     if (typeof property === "object" && property.$ref) {

--- a/src/json-completion.ts
+++ b/src/json-completion.ts
@@ -270,6 +270,7 @@ export class JSONCompletion {
 
     // Get matching schemas
     const schemas = this.getSchemas(schema, ctx);
+    debug.log("xxx", "propertyCompletion schemas", schemas);
 
     schemas.forEach((s) => {
       if (typeof s !== "object") {
@@ -814,8 +815,9 @@ export class JSONCompletion {
     debug.log("xxx", "pointer..", JSON.stringify(pointer));
 
     // For some reason, it returns undefined schema for the root pointer
+    // We use the root schema in that case as the relevant (sub)schema
     if (!pointer || pointer === "/") {
-      return [schema];
+      subSchema = this.expandSchemaProperty(schema, schema) ?? schema;
     }
     // const subSchema = new Draft07(this.schema).getSchema(pointer);
     debug.log("xxx", "subSchema..", subSchema);

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -23,10 +23,17 @@ export const surroundingDoubleQuotesToSingle = (str: string) => {
 export const getWord = (
   doc: Text,
   node: SyntaxNode | null,
-  stripQuotes = true
+  stripQuotes = true,
+  onlyEvenQuotes = true
 ) => {
   const word = node ? doc.sliceString(node.from, node.to) : "";
-  return stripQuotes ? stripSurroundingQuotes(word) : word;
+  if (!stripQuotes) {
+    return word;
+  }
+  if (onlyEvenQuotes) {
+    return stripSurroundingQuotes(word);
+  }
+  return word.replace(/(^["'])|(["']$)/g, "");
 };
 
 export const isInvalidValueNode = (node: SyntaxNode, mode: JSONMode) => {


### PR DESCRIPTION
Improvements to completion logic (mainly for top level). In true TDD fashion, I'm fairly confident with the changes given the tests are all passing.

Added additional tests for
- curly brace in default behavior https://github.com/acao/codemirror-json-schema/issues/96
- autocomplete for a schema with top level $ref
- autocomplete for a schema with top level complex type

I wanted to also work on the "include value completions for boolean" test case but there's a bit extra work (when completing the property value and the node used for the completion is different from the original node passed in to `getValueCompletions()`, we also need to figure out the correct `from` and `to` values for the completion context, so that applying the completion replaces the correct things, otherwise it will replace the original node which may not be what we want) to be done to get it working as expected, so decided to tackle part of it but leave it commented out for now.