### PR TITLE
fix: type issue where barrel exported functions could not be imported without a type error

### DIFF
--- a/.changeset/empty-islands-punch.md
+++ b/.changeset/empty-islands-punch.md
@@ -1,0 +1,5 @@
+---
+"codemirror-json-schema": patch
+---
+
+Fixed type issue where barrel exported functions could not be imported without a type error

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,20 @@ export type {
   JSONPartialPointerData,
 } from "./types";
 
-export * from "./parsers/json-parser";
-export * from "./utils/json-pointers";
+export {
+  parseJSONDocumentState,
+  parseJSONDocument,
+} from "./parsers/json-parser";
 
-export * from "./features/state";
+export {
+  getJsonPointerAt,
+  jsonPointerForPosition,
+  getJsonPointers,
+} from "./utils/json-pointers";
+
+export {
+  schemaStateField,
+  updateSchema,
+  getJSONSchema,
+  stateExtensions,
+} from "./features/state";


### PR DESCRIPTION
Importing certain functions, for example `stateExtensions`, would result in a type error:
<img width="727" height="168" alt="SCR-20250728-lbde" src="https://github.com/user-attachments/assets/05273ad7-8230-4a8a-82ee-f10e0e2326da" />

This issue seemed to effect any export from `./src/index.ts` that was barrel exported. This PR updates any barrel exported values within `./src/index.ts` to be named exports instead. 

This fixes the type issue:
<img width="542" height="180" alt="SCR-20250728-ldjj" src="https://github.com/user-attachments/assets/c6ec26f4-f373-4eb2-811a-7e0078bd75a1" />
