### PR TITLE
fix(dev): fix schemastore addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ const json5State = EditorState.create({
     linter(
       json5SchemaLinter({
         needsRefresh: handleRefresh,
-      })
+      }),
     ),
     hoverTooltip(json5SchemaHover()),
     json5Language.data.of({
@@ -247,9 +247,7 @@ schemaSelect!.onchange = async (e) => {
     return;
   }
   // parse the remote schema spec to json
-  const data = await (
-    await fetch(`https://json.schemastore.org/${val}`)
-  ).json();
+  const data = await (await fetch(`https://www.schemastore.org/${val}`)).json();
   // this will update the schema state field, in an editor specific way
   updateSchema(editor, data);
 };

--- a/dev/geojson.json
+++ b/dev/geojson.json
@@ -118,7 +118,7 @@
     }
   },
   "description": "This object represents a geometry, feature, or collection of features.",
-  "id": "https://json.schemastore.org/geojson",
+  "id": "https://www.schemastore.org/geojson",
   "oneOf": [
     {
       "title": "Point",

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -151,9 +151,7 @@ const getSchema = async (val: string) => {
     return;
   }
 
-  const data = await (
-    await fetch(`https://json.schemastore.org/${val}`)
-  ).json();
+  const data = await (await fetch(`https://www.schemastore.org/${val}`)).json();
   schemaCache.set(val, data);
   handleSchemaChange(data);
 };

--- a/dev/package.schema.json
+++ b/dev/package.schema.json
@@ -727,22 +727,22 @@
       "$ref": "#"
     },
     "eslintConfig": {
-      "$ref": "https://json.schemastore.org/eslintrc.json"
+      "$ref": "https://www.schemastore.org/eslintrc.json"
     },
     "prettier": {
-      "$ref": "https://json.schemastore.org/prettierrc.json"
+      "$ref": "https://www.schemastore.org/prettierrc.json"
     },
     "stylelint": {
-      "$ref": "https://json.schemastore.org/stylelintrc.json"
+      "$ref": "https://www.schemastore.org/stylelintrc.json"
     },
     "ava": {
-      "$ref": "https://json.schemastore.org/ava.json"
+      "$ref": "https://www.schemastore.org/ava.json"
     },
     "release": {
-      "$ref": "https://json.schemastore.org/semantic-release.json"
+      "$ref": "https://www.schemastore.org/semantic-release.json"
     },
     "jscpd": {
-      "$ref": "https://json.schemastore.org/jscpd.json"
+      "$ref": "https://www.schemastore.org/jscpd.json"
     }
   },
   "anyOf": [


### PR DESCRIPTION
json.schemastore.org now redirects to www.schemastore.org, but json.s.o redirects are set up without CORS headers, breaking the dev examples. Switch to www.s.o instead, which provides CORS.