### PR TITLE
feat(completion): allow overriding renderer, other rendering-related fixes

### DIFF
--- a/.changeset/beige-gorillas-occur.md
+++ b/.changeset/beige-gorillas-occur.md
@@ -1,0 +1,5 @@
+---
+"codemirror-json-schema": patch
+---
+
+Fix description rendering on empty or no description, and enums

--- a/.changeset/lemon-apricots-laugh.md
+++ b/.changeset/lemon-apricots-laugh.md
@@ -1,0 +1,5 @@
+---
+"codemirror-json-schema": minor
+---
+
+Add formatInfo option to completion to control description rendering

--- a/src/features/__tests__/json-completion.spec.ts
+++ b/src/features/__tests__/json-completion.spec.ts
@@ -20,7 +20,6 @@ describe.each([
         label: "foo",
         type: "property",
         detail: "string",
-        info: "",
         template: '"foo": "#{}"',
       },
     ],
@@ -41,12 +40,10 @@ describe.each([
         label: "oneOfEg2",
         type: "property",
         detail: "",
-        info: "",
         template: '"oneOfEg2": #{}',
       },
       {
         detail: "",
-        info: "",
         label: "oneOfObject",
         template: '"oneOfObject": #{}',
         type: "property",
@@ -169,7 +166,6 @@ describe.each([
       {
         type: "property",
         detail: "object",
-        info: "",
         label: "object",
         template: '"object": {#{}}',
       },
@@ -177,7 +173,6 @@ describe.each([
         template: '"objectWithRef": {#{}}',
         label: "objectWithRef",
         detail: "",
-        info: "",
         type: "property",
       },
     ],
@@ -218,7 +213,6 @@ describe.each([
     expectedResults: [
       {
         detail: "string",
-        info: "",
         label: "foo",
         template: '"foo": "#{}"',
         type: "property",
@@ -232,28 +226,24 @@ describe.each([
     expectedResults: [
       {
         detail: "string",
-        info: "",
         label: "foo",
         template: '"foo": "#{}"',
         type: "property",
       },
       {
         detail: "number",
-        info: "",
         label: "bar",
         template: '"bar": #{0}',
         type: "property",
       },
       {
         detail: "string",
-        info: "",
         label: "apple",
         template: '"apple": "#{}"',
         type: "property",
       },
       {
         detail: "number",
-        info: "",
         label: "banana",
         template: '"banana": #{0}',
         type: "property",
@@ -268,7 +258,6 @@ describe.each([
     expectedResults: [
       {
         detail: "string",
-        info: "",
         label: "foo",
         template: '"foo": "#{}"',
         type: "property",
@@ -283,14 +272,12 @@ describe.each([
       {
         type: "property",
         detail: "array",
-        info: "",
         label: "arrayOfObjects",
         template: '"arrayOfObjects": [#{}]',
       },
       {
         type: "property",
         detail: "array",
-        info: "",
         label: "arrayOfOneOf",
         template: '"arrayOfOneOf": [#{}]',
       },
@@ -303,14 +290,12 @@ describe.each([
     expectedResults: [
       {
         detail: "string",
-        info: "",
         label: "foo",
         template: `"foo": "#{}"`,
         type: "property",
       },
       {
         detail: "number",
-        info: "",
         label: "bar",
         template: '"bar": #{0}',
         type: "property",
@@ -324,28 +309,24 @@ describe.each([
     expectedResults: [
       {
         detail: "string",
-        info: "",
         label: "foo",
         template: '"foo": "#{}"',
         type: "property",
       },
       {
         detail: "number",
-        info: "",
         label: "bar",
         template: '"bar": #{0}',
         type: "property",
       },
       {
         detail: "string",
-        info: "",
         label: "apple",
         template: '"apple": "#{}"',
         type: "property",
       },
       {
         detail: "number",
-        info: "",
         label: "banana",
         template: '"banana": #{0}',
         type: "property",
@@ -360,14 +341,12 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "foo",
         template: '"foo": "#{}"',
       },
       {
         type: "property",
         detail: "number",
-        info: "",
         label: "bar",
         template: '"bar": #{0}',
       },
@@ -382,14 +361,12 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "foo",
         template: '"foo": "#{}"',
       },
       {
         type: "property",
         detail: "number",
-        info: "",
         label: "bar",
         template: '"bar": #{0}',
       },
@@ -404,7 +381,6 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "test1Props",
         template: '"test1Props": "#{}"',
       },
@@ -421,7 +397,6 @@ describe.each([
         label: "foo",
         type: "property",
         detail: "string",
-        info: "",
         template: "foo: '#{}'",
       },
     ],
@@ -442,12 +417,10 @@ describe.each([
         label: "oneOfEg2",
         type: "property",
         detail: "",
-        info: "",
         template: "'oneOfEg2': #{}",
       },
       {
         detail: "",
-        info: "",
         label: "oneOfObject",
         template: "'oneOfObject': #{}",
         type: "property",
@@ -544,28 +517,24 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "foo",
         template: "'foo': '#{}'",
       },
       {
         type: "property",
         detail: "number",
-        info: "",
         label: "bar",
         template: "'bar': #{0}",
       },
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "apple",
         template: "'apple': '#{}'",
       },
       {
         type: "property",
         detail: "number",
-        info: "",
         label: "banana",
         template: "'banana': #{0}",
       },
@@ -579,7 +548,6 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "test1Props",
         template: "test1Props: '#{}'",
       },
@@ -596,7 +564,6 @@ describe.each([
         label: "foo",
         type: "property",
         detail: "string",
-        info: "",
         template: "foo: #{}",
       },
     ],
@@ -617,12 +584,10 @@ describe.each([
         label: "oneOfEg2",
         type: "property",
         detail: "",
-        info: "",
         template: "oneOfEg2: #{}",
       },
       {
         detail: "",
-        info: "",
         label: "oneOfObject",
         template: "oneOfObject: #{}",
         type: "property",
@@ -684,7 +649,6 @@ describe.each([
       {
         type: "property",
         detail: "object",
-        info: "",
         label: "object",
         template: "object: #{}",
       },
@@ -692,7 +656,6 @@ describe.each([
         template: "objectWithRef: #{}",
         label: "objectWithRef",
         detail: "",
-        info: "",
         type: "property",
       },
     ],
@@ -719,14 +682,12 @@ describe.each([
       {
         type: "property",
         detail: "number",
-        info: "",
         label: "bar",
         template: "bar: #{0}",
       },
       {
         type: "property",
         detail: "number",
-        info: "",
         label: "banana",
         template: "banana: #{0}",
       },
@@ -740,14 +701,12 @@ describe.each([
       {
         type: "property",
         detail: "array",
-        info: "",
         label: "arrayOfObjects",
         template: "arrayOfObjects: [#{}]",
       },
       {
         type: "property",
         detail: "array",
-        info: "",
         label: "arrayOfOneOf",
         template: "arrayOfOneOf: [#{}]",
       },
@@ -760,7 +719,6 @@ describe.each([
     expectedResults: [
       {
         detail: "string",
-        info: "",
         label: "foo",
         template: "foo: #{}",
         type: "property",
@@ -774,14 +732,12 @@ describe.each([
     expectedResults: [
       {
         detail: "number",
-        info: "",
         label: "bar",
         template: "bar: #{0}",
         type: "property",
       },
       {
         detail: "number",
-        info: "",
         label: "banana",
         template: "banana: #{0}",
         type: "property",
@@ -796,7 +752,6 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "test1Props",
         template: "test1Props: #{}",
       },
@@ -818,7 +773,6 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "type1Prop",
         template: "type1Prop: '#{}'",
       },
@@ -833,21 +787,18 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "type1Prop",
         template: `"type1Prop": '#{}'`,
       },
       {
         type: "property",
         detail: "",
-        info: "",
         label: "commonEnum",
         template: `"commonEnum": #{}`,
       },
       {
         type: "property",
         detail: "",
-        info: "",
         label: "commonEnumWithDifferentValues",
         template: `"commonEnumWithDifferentValues": #{}`,
       },
@@ -862,12 +813,10 @@ describe.each([
       {
         label: "type1Specific",
         apply: `'type1Specific'`,
-        info: "",
       },
       {
         label: "common",
         apply: `'common'`,
-        info: "",
       },
     ],
     schema: testSchemaConditionalPropertiesOnSameObject,
@@ -880,12 +829,10 @@ describe.each([
       {
         label: "type2Specific",
         apply: `'type2Specific'`,
-        info: "",
       },
       {
         label: "common",
         apply: `'common'`,
-        info: "",
       },
     ],
     schema: testSchemaConditionalPropertiesOnSameObject,
@@ -898,13 +845,11 @@ describe.each([
       {
         label: "type1",
         apply: "'type1'",
-        info: "",
         type: "string",
       },
       {
         label: "type2",
         apply: "'type2'",
-        info: "",
         type: "string",
       },
     ],
@@ -918,35 +863,30 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "type",
         template: `"type": #{}`,
       },
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "type1Prop",
         template: `"type1Prop": '#{}'`,
       },
       {
         type: "property",
         detail: "",
-        info: "",
         label: "commonEnum",
         template: `"commonEnum": #{}`,
       },
       {
         type: "property",
         detail: "",
-        info: "",
         label: "commonEnumWithDifferentValues",
         template: `"commonEnumWithDifferentValues": #{}`,
       },
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "type2Prop",
         template: `"type2Prop": '#{}'`,
       },
@@ -973,7 +913,6 @@ describe.each([
       {
         type: "property",
         detail: "string",
-        info: "",
         label: "type1Prop",
         template: "type1Prop: '#{}'",
       },

--- a/src/features/__tests__/json-completion.spec.ts
+++ b/src/features/__tests__/json-completion.spec.ts
@@ -862,12 +862,12 @@ describe.each([
       {
         label: "type1Specific",
         apply: `'type1Specific'`,
-        // info: "",
+        info: "",
       },
       {
         label: "common",
         apply: `'common'`,
-        // info: "",
+        info: "",
       },
     ],
     schema: testSchemaConditionalPropertiesOnSameObject,
@@ -880,12 +880,12 @@ describe.each([
       {
         label: "type2Specific",
         apply: `'type2Specific'`,
-        // info: "",
+        info: "",
       },
       {
         label: "common",
         apply: `'common'`,
-        // info: "",
+        info: "",
       },
     ],
     schema: testSchemaConditionalPropertiesOnSameObject,
@@ -898,11 +898,13 @@ describe.each([
       {
         label: "type1",
         apply: "'type1'",
+        info: "",
         type: "string",
       },
       {
         label: "type2",
         apply: "'type2'",
+        info: "",
         type: "string",
       },
     ],

--- a/src/features/completion.ts
+++ b/src/features/completion.ts
@@ -842,7 +842,7 @@ export class JSONCompletion {
         type: schema.type?.toString(),
         ...this.getAppliedValue(schema.const),
 
-        info: schema.description,
+        info: () => this.formatInfo(schema.description ?? ""),
       });
     }
 
@@ -852,7 +852,7 @@ export class JSONCompletion {
         collector.add({
           type: schema.type?.toString(),
           ...this.getAppliedValue(enm),
-          info: schema.description,
+          info: () => this.formatInfo(schema.description ?? ""),
         });
       }
     }

--- a/src/features/completion.ts
+++ b/src/features/completion.ts
@@ -353,7 +353,6 @@ export class JSONCompletion {
       if (properties) {
         Object.entries(properties).forEach(([key, value]) => {
           if (typeof value === "object") {
-            const description = value.description ?? "";
             const type = value.type ?? "";
             const typeStr = Array.isArray(type) ? type.toString() : type;
             const completion: Completion = {
@@ -368,7 +367,9 @@ export class JSONCompletion {
               ),
               type: "property",
               detail: typeStr,
-              info: () => this.formatInfo(description),
+              info: value.description
+                ? () => this.formatInfo(value.description!)
+                : undefined,
             };
             collector.add(this.applySnippetCompletion(completion));
           }
@@ -842,7 +843,9 @@ export class JSONCompletion {
         type: schema.type?.toString(),
         ...this.getAppliedValue(schema.const),
 
-        info: () => this.formatInfo(schema.description ?? ""),
+        info: schema.description
+          ? () => this.formatInfo(schema.description!)
+          : undefined,
       });
     }
 
@@ -852,7 +855,10 @@ export class JSONCompletion {
         collector.add({
           type: schema.type?.toString(),
           ...this.getAppliedValue(enm),
-          info: () => this.formatInfo(schema.description ?? ""),
+
+          info: schema.description
+            ? () => this.formatInfo(schema.description!)
+            : undefined,
         });
       }
     }

--- a/src/features/completion.ts
+++ b/src/features/completion.ts
@@ -55,6 +55,7 @@ class CompletionCollector {
 export interface JSONCompletionOptions {
   mode?: JSONMode;
   jsonParser?: DocumentParser;
+  formatInfo?: (description: string) => HTMLElement;
 }
 
 function isRealSchema(
@@ -67,6 +68,11 @@ function isRealSchema(
     subSchema.type === "undefined"
   );
 }
+
+const defaultFormatInfo = (description: string) =>
+  el("div", {
+    inner: renderMarkdown(description),
+  });
 
 export class JSONCompletion {
   private originalSchema: JSONSchema7 | null = null;
@@ -81,12 +87,14 @@ export class JSONCompletion {
   private laxSchema: JSONSchema7 | null = null;
   private mode: JSONMode = MODES.JSON;
   private parser: DocumentParser;
+  private formatInfo = defaultFormatInfo;
 
   // private lastKnownValidData: object | null = null;
 
   constructor(private opts: JSONCompletionOptions) {
     this.mode = opts.mode ?? MODES.JSON;
     this.parser = this.opts?.jsonParser ?? getDefaultParser(this.mode);
+    this.formatInfo = opts.formatInfo ?? defaultFormatInfo;
   }
 
   public doComplete(ctx: CompletionContext) {
@@ -360,10 +368,7 @@ export class JSONCompletion {
               ),
               type: "property",
               detail: typeStr,
-              info: () =>
-                el("div", {
-                  inner: renderMarkdown(description),
-                }),
+              info: () => this.formatInfo(description),
             };
             collector.add(this.applySnippetCompletion(completion));
           }


### PR DESCRIPTION
Introduce `formatInfo` for completion, like `formatHover` for hover, to let consumer control description rendering.
Fix renderer not being applied on enums.
Use renderer only when there are description to avoid visual artifacts. (To check, type property `publishConfig` on demo with package.json schema.)